### PR TITLE
Allow negative numbers in integer definition

### DIFF
--- a/modules/common_log_format.lua
+++ b/modules/common_log_format.lua
@@ -24,7 +24,7 @@ local unreserved    = l.alnum + l.S"-._~"
 local sub_delims    = l.S"!$&'()*+,;="
 
 local last_literal  = l.space
-local integer       = l.digit^1 / tonumber
+local integer       = l.P"-"^-1 * l.digit^1 / tonumber
 local double        = l.digit^1 * "." * l.digit^1 / tonumber
 local msec_time     = double / dt.seconds_to_ns
 local host          = l.Ct(l.Cg(ip.v4, "value") * l.Cg(l.Cc"ipv4", "representation"))


### PR DESCRIPTION
Allow negative numbers for integers in common log format. Haproxy returns -1 for some fields when they are not applicable for various reasons.